### PR TITLE
IDEA-330128 Ignore jdk/internal/vm/FillerArray objects due to tag reclamation issues with this class

### DIFF
--- a/test_data/outs/execution.RetainedSizeByClassesForObject.out
+++ b/test_data/outs/execution.RetainedSizeByClassesForObject.out
@@ -1,0 +1,11 @@
+Agent loaded
+{
+	"minValue": 0,
+	"maxValue": 100,
+	"currentValue": 100,
+	"message": "Finished!"
+}
+TIMEOUT
+TIMEOUT
+OK
+CANCELLED

--- a/test_data/outs/execution.ShallowAndRetainedSizeByClassesForObject.out
+++ b/test_data/outs/execution.ShallowAndRetainedSizeByClassesForObject.out
@@ -1,0 +1,11 @@
+Agent loaded
+{
+	"minValue": 0,
+	"maxValue": 100,
+	"currentValue": 100,
+	"message": "Finished!"
+}
+TIMEOUT
+TIMEOUT
+OK
+CANCELLED

--- a/test_data/outs/execution.ShallowSizeByClassesForObject.out
+++ b/test_data/outs/execution.ShallowSizeByClassesForObject.out
@@ -1,0 +1,11 @@
+Agent loaded
+{
+	"minValue": 0,
+	"maxValue": 100,
+	"currentValue": 100,
+	"message": "Finished!"
+}
+TIMEOUT
+TIMEOUT
+OK
+CANCELLED

--- a/test_data/outs/size.WithHeldObjects1.out
+++ b/test_data/outs/size.WithHeldObjects1.out
@@ -11,18 +11,18 @@ Held objects:
 [common.TestTreeNode$Impl1: node 2]
 [common.TestTreeNode$Impl2: node 1]
 Shallow sizes:
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 3] -> 24
-	[common.TestTreeNode$Impl1: node 5] -> 24
 Retained sizes:
+	[common.TestTreeNode$Impl1: node 5] -> 72
 	[common.TestTreeNode$Impl2: node 1] -> 48
 	[common.TestTreeNode$Impl3: node 3] -> 48
-	[common.TestTreeNode$Impl1: node 5] -> 72
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 Retained sizes:

--- a/test_data/outs/size.WithHeldObjects2.out
+++ b/test_data/outs/size.WithHeldObjects2.out
@@ -7,13 +7,13 @@ Held objects:
 [common.TestTreeNode$Impl1: node 5]
 [common.TestTreeNode$Impl2: node 1]
 Shallow sizes:
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 6] -> 24
-	[common.TestTreeNode$Impl1: node 5] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl2: node 1] -> 120
-	[common.TestTreeNode$Impl3: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
+	[common.TestTreeNode$Impl3: node 6] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
 	[common.TestTreeNode$Impl1: node 2] -> 24
@@ -43,13 +43,13 @@ Held objects:
 [common.TestTreeNode$Impl1: node 5]
 [common.TestTreeNode$Impl2: node 1]
 Shallow sizes:
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 6] -> 24
-	[common.TestTreeNode$Impl1: node 5] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl2: node 1] -> 48
-	[common.TestTreeNode$Impl3: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
+	[common.TestTreeNode$Impl3: node 6] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
 	[common.TestTreeNode$Impl1: node 2] -> 24

--- a/test_data/outs/size.WithHeldObjects3.out
+++ b/test_data/outs/size.WithHeldObjects3.out
@@ -17,9 +17,9 @@ Retained sizes:
 Class common.TestTreeNode$Impl1
 Shallow sizes:
 	[common.TestTreeNode$Impl1: node 1] -> 24
-	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 Retained sizes:
@@ -63,10 +63,10 @@ Retained sizes:
 	[common.TestTreeNode$Impl3: node 5] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 1] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 Retained sizes:
@@ -100,15 +100,15 @@ Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
 	[common.TestTreeNode$Impl3: node 5] -> 24
 Retained sizes:
+	[common.TestTreeNode$Impl3: node 5] -> 96
 	[common.TestTreeNode$Impl1: node 1] -> 48
 	[common.TestTreeNode$Impl2: node 3] -> 48
-	[common.TestTreeNode$Impl3: node 5] -> 96
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 1] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 Retained sizes:

--- a/test_data/outs/size.WithHeldObjects4.out
+++ b/test_data/outs/size.WithHeldObjects4.out
@@ -11,17 +11,17 @@ Held objects:
 [common.TestTreeNode$Impl1: node 9]
 [common.TestTreeNode$Impl2: node 3]
 Shallow sizes:
-	[common.TestTreeNode$Impl2: node 3] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 9] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl2: node 3] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 216
-	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 72
 	[common.TestTreeNode$Impl1: node 9] -> 72
 	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl1: node 4] -> 24
 Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
 	[common.TestTreeNode$Impl3: node 1] -> 24
@@ -32,23 +32,23 @@ Retained sizes:
 	[common.TestTreeNode$Impl4: node 2] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 5] -> 24
-	[common.TestTreeNode$Impl1: node 9] -> 24
+	[common.TestTreeNode$Impl1: node 10] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
-	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl1: node 9] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl1: node 5] -> 72
 	[common.TestTreeNode$Impl1: node 9] -> 72
+	[common.TestTreeNode$Impl1: node 10] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
-	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
 Class common.TestTreeNode$Impl2
 Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
@@ -75,17 +75,17 @@ Shallow size: 24, Retained size: 24
 Held objects:
 [common.TestTreeNode$Impl4: node 2]
 Shallow sizes:
-	[common.TestTreeNode$Impl2: node 3] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 9] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl2: node 3] -> 24
 Retained sizes:
-	[common.TestTreeNode$Impl2: node 3] -> 48
-	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 72
-	[common.TestTreeNode$Impl1: node 9] -> 24
+	[common.TestTreeNode$Impl2: node 3] -> 48
 	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 9] -> 24
 Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
 	[common.TestTreeNode$Impl3: node 1] -> 24
@@ -96,23 +96,23 @@ Retained sizes:
 	[common.TestTreeNode$Impl4: node 2] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 5] -> 24
+	[common.TestTreeNode$Impl1: node 10] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 	[common.TestTreeNode$Impl1: node 9] -> 24
-	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl1: node 5] -> 72
+	[common.TestTreeNode$Impl1: node 10] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 	[common.TestTreeNode$Impl1: node 9] -> 24
-	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
 Class common.TestTreeNode$Impl2
 Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
@@ -149,12 +149,12 @@ Held objects:
 [common.TestTreeNode$Impl4: node 2]
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 8] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
+	[common.TestTreeNode$Impl1: node 8] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl1: node 11] -> 144
 	[common.TestTreeNode$Impl1: node 10] -> 120

--- a/test_data/outs/size.WithHeldObjects5.out
+++ b/test_data/outs/size.WithHeldObjects5.out
@@ -10,12 +10,12 @@ Shallow size: 24, Retained size: 24
 Held objects:
 [common.TestTreeNode$Impl2: node 1]
 Shallow sizes:
-	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
+	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 6] -> 24
 Retained sizes:
-	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 72
+	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 6] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:

--- a/test_data/outs/size.classes.Inheritance.out
+++ b/test_data/outs/size.classes.Inheritance.out
@@ -1,25 +1,25 @@
 Agent loaded
 Shallow sizes by class:
-	size.classes.Inheritance$Interface -> 48
 	size.classes.Inheritance$Abstract -> 48
 	size.classes.Inheritance$First -> 48
+	size.classes.Inheritance$Interface -> 48
 	size.classes.Inheritance$Second -> 32
 	size.classes.Inheritance$Third -> 16
 Retained sizes by class:
-	size.classes.Inheritance$Interface -> 48
 	size.classes.Inheritance$Abstract -> 48
 	size.classes.Inheritance$First -> 48
+	size.classes.Inheritance$Interface -> 48
 	size.classes.Inheritance$Second -> 32
 	size.classes.Inheritance$Third -> 16
 Shallow sizes by class:
-	size.classes.Inheritance$Interface -> 48
 	size.classes.Inheritance$Abstract -> 48
 	size.classes.Inheritance$First -> 48
+	size.classes.Inheritance$Interface -> 48
 	size.classes.Inheritance$Second -> 32
 	size.classes.Inheritance$Third -> 16
 Retained sizes by class:
-	size.classes.Inheritance$Interface -> 48
 	size.classes.Inheritance$Abstract -> 48
 	size.classes.Inheritance$First -> 48
+	size.classes.Inheritance$Interface -> 48
 	size.classes.Inheritance$Second -> 32
 	size.classes.Inheritance$Third -> 16

--- a/test_data/outs/size.classes.ManyClasses.out
+++ b/test_data/outs/size.classes.ManyClasses.out
@@ -1,5 +1,5 @@
 Agent loaded
 Shallow sizes by class:
-	size.classes.ManyClasses$1ThirdClass -> 0
-	size.classes.OneClass -> 16
 	size.classes.ManyClasses$1SecondClass -> 32
+	size.classes.OneClass -> 16
+	size.classes.ManyClasses$1ThirdClass -> 0

--- a/test_data/outs/size.classes.ManyClassesTwice.out
+++ b/test_data/outs/size.classes.ManyClassesTwice.out
@@ -1,9 +1,9 @@
 Agent loaded
 Shallow sizes by class:
-	size.classes.ManyClasses$1ThirdClass -> 0
-	size.classes.OneClass -> 16
 	size.classes.ManyClasses$1SecondClass -> 32
-Shallow sizes by class:
+	size.classes.OneClass -> 16
 	size.classes.ManyClasses$1ThirdClass -> 0
-	size.classes.OneClass -> 32
+Shallow sizes by class:
 	size.classes.ManyClasses$1SecondClass -> 64
+	size.classes.OneClass -> 32
+	size.classes.ManyClasses$1ThirdClass -> 0

--- a/test_data/outs32/execution.RetainedSizeByClassesForObject.out
+++ b/test_data/outs32/execution.RetainedSizeByClassesForObject.out
@@ -1,0 +1,11 @@
+Agent loaded
+{
+	"minValue": 0,
+	"maxValue": 100,
+	"currentValue": 100,
+	"message": "Finished!"
+}
+TIMEOUT
+TIMEOUT
+OK
+CANCELLED

--- a/test_data/outs32/execution.ShallowAndRetainedSizeByClassesForObject.out
+++ b/test_data/outs32/execution.ShallowAndRetainedSizeByClassesForObject.out
@@ -1,0 +1,11 @@
+Agent loaded
+{
+	"minValue": 0,
+	"maxValue": 100,
+	"currentValue": 100,
+	"message": "Finished!"
+}
+TIMEOUT
+TIMEOUT
+OK
+CANCELLED

--- a/test_data/outs32/execution.ShallowSizeByClassesForObject.out
+++ b/test_data/outs32/execution.ShallowSizeByClassesForObject.out
@@ -1,0 +1,11 @@
+Agent loaded
+{
+	"minValue": 0,
+	"maxValue": 100,
+	"currentValue": 100,
+	"message": "Finished!"
+}
+TIMEOUT
+TIMEOUT
+OK
+CANCELLED

--- a/test_data/outs32/size.WithHeldObjects1.out
+++ b/test_data/outs32/size.WithHeldObjects1.out
@@ -11,18 +11,18 @@ Held objects:
 [common.TestTreeNode$Impl1: node 2]
 [common.TestTreeNode$Impl2: node 1]
 Shallow sizes:
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 3] -> 24
-	[common.TestTreeNode$Impl1: node 5] -> 24
 Retained sizes:
+	[common.TestTreeNode$Impl1: node 5] -> 72
 	[common.TestTreeNode$Impl2: node 1] -> 48
 	[common.TestTreeNode$Impl3: node 3] -> 48
-	[common.TestTreeNode$Impl1: node 5] -> 72
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 Retained sizes:

--- a/test_data/outs32/size.WithHeldObjects2.out
+++ b/test_data/outs32/size.WithHeldObjects2.out
@@ -7,13 +7,13 @@ Held objects:
 [common.TestTreeNode$Impl1: node 5]
 [common.TestTreeNode$Impl2: node 1]
 Shallow sizes:
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 6] -> 24
-	[common.TestTreeNode$Impl1: node 5] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl2: node 1] -> 120
-	[common.TestTreeNode$Impl3: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
+	[common.TestTreeNode$Impl3: node 6] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
 	[common.TestTreeNode$Impl1: node 2] -> 24
@@ -43,13 +43,13 @@ Held objects:
 [common.TestTreeNode$Impl1: node 5]
 [common.TestTreeNode$Impl2: node 1]
 Shallow sizes:
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 6] -> 24
-	[common.TestTreeNode$Impl1: node 5] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl2: node 1] -> 48
-	[common.TestTreeNode$Impl3: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
+	[common.TestTreeNode$Impl3: node 6] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
 	[common.TestTreeNode$Impl1: node 2] -> 24

--- a/test_data/outs32/size.WithHeldObjects3.out
+++ b/test_data/outs32/size.WithHeldObjects3.out
@@ -17,9 +17,9 @@ Retained sizes:
 Class common.TestTreeNode$Impl1
 Shallow sizes:
 	[common.TestTreeNode$Impl1: node 1] -> 24
-	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 Retained sizes:
@@ -63,10 +63,10 @@ Retained sizes:
 	[common.TestTreeNode$Impl3: node 5] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 1] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 Retained sizes:
@@ -100,15 +100,15 @@ Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
 	[common.TestTreeNode$Impl3: node 5] -> 24
 Retained sizes:
+	[common.TestTreeNode$Impl3: node 5] -> 96
 	[common.TestTreeNode$Impl1: node 1] -> 48
 	[common.TestTreeNode$Impl2: node 3] -> 48
-	[common.TestTreeNode$Impl3: node 5] -> 96
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 1] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 Retained sizes:

--- a/test_data/outs32/size.WithHeldObjects4.out
+++ b/test_data/outs32/size.WithHeldObjects4.out
@@ -11,17 +11,17 @@ Held objects:
 [common.TestTreeNode$Impl1: node 9]
 [common.TestTreeNode$Impl2: node 3]
 Shallow sizes:
-	[common.TestTreeNode$Impl2: node 3] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 9] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl2: node 3] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 216
-	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 72
 	[common.TestTreeNode$Impl1: node 9] -> 72
 	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl1: node 4] -> 24
 Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
 	[common.TestTreeNode$Impl3: node 1] -> 24
@@ -32,23 +32,23 @@ Retained sizes:
 	[common.TestTreeNode$Impl4: node 2] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 5] -> 24
-	[common.TestTreeNode$Impl1: node 9] -> 24
+	[common.TestTreeNode$Impl1: node 10] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
-	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl1: node 9] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl1: node 5] -> 72
 	[common.TestTreeNode$Impl1: node 9] -> 72
+	[common.TestTreeNode$Impl1: node 10] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
-	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
 Class common.TestTreeNode$Impl2
 Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
@@ -75,17 +75,17 @@ Shallow size: 24, Retained size: 24
 Held objects:
 [common.TestTreeNode$Impl4: node 2]
 Shallow sizes:
-	[common.TestTreeNode$Impl2: node 3] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 9] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl2: node 3] -> 24
 Retained sizes:
-	[common.TestTreeNode$Impl2: node 3] -> 48
-	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 72
-	[common.TestTreeNode$Impl1: node 9] -> 24
+	[common.TestTreeNode$Impl2: node 3] -> 48
 	[common.TestTreeNode$Impl1: node 11] -> 24
+	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 9] -> 24
 Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
 	[common.TestTreeNode$Impl3: node 1] -> 24
@@ -96,23 +96,23 @@ Retained sizes:
 	[common.TestTreeNode$Impl4: node 2] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 5] -> 24
+	[common.TestTreeNode$Impl1: node 10] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
+	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 	[common.TestTreeNode$Impl1: node 9] -> 24
-	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl1: node 5] -> 72
+	[common.TestTreeNode$Impl1: node 10] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 4] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
 	[common.TestTreeNode$Impl1: node 8] -> 24
 	[common.TestTreeNode$Impl1: node 9] -> 24
-	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 11] -> 24
 Class common.TestTreeNode$Impl2
 Shallow sizes:
 	[common.TestTreeNode$Impl2: node 3] -> 24
@@ -149,12 +149,12 @@ Held objects:
 [common.TestTreeNode$Impl4: node 2]
 Class common.TestTreeNode$Impl1
 Shallow sizes:
-	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 10] -> 24
-	[common.TestTreeNode$Impl1: node 8] -> 24
+	[common.TestTreeNode$Impl1: node 11] -> 24
 	[common.TestTreeNode$Impl1: node 5] -> 24
 	[common.TestTreeNode$Impl1: node 6] -> 24
 	[common.TestTreeNode$Impl1: node 7] -> 24
+	[common.TestTreeNode$Impl1: node 8] -> 24
 Retained sizes:
 	[common.TestTreeNode$Impl1: node 11] -> 144
 	[common.TestTreeNode$Impl1: node 10] -> 120

--- a/test_data/outs32/size.WithHeldObjects5.out
+++ b/test_data/outs32/size.WithHeldObjects5.out
@@ -10,12 +10,12 @@ Shallow size: 24, Retained size: 24
 Held objects:
 [common.TestTreeNode$Impl2: node 1]
 Shallow sizes:
-	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 24
+	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 6] -> 24
 Retained sizes:
-	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl1: node 2] -> 72
+	[common.TestTreeNode$Impl2: node 1] -> 24
 	[common.TestTreeNode$Impl3: node 6] -> 24
 Class common.TestTreeNode$Impl1
 Shallow sizes:

--- a/test_data/outs32/size.classes.Inheritance.out
+++ b/test_data/outs32/size.classes.Inheritance.out
@@ -1,25 +1,25 @@
 Agent loaded
 Shallow sizes by class:
-	size.classes.Inheritance$Interface -> 24
 	size.classes.Inheritance$Abstract -> 24
 	size.classes.Inheritance$First -> 24
+	size.classes.Inheritance$Interface -> 24
 	size.classes.Inheritance$Second -> 16
 	size.classes.Inheritance$Third -> 8
 Retained sizes by class:
-	size.classes.Inheritance$Interface -> 24
 	size.classes.Inheritance$Abstract -> 24
 	size.classes.Inheritance$First -> 24
+	size.classes.Inheritance$Interface -> 24
 	size.classes.Inheritance$Second -> 16
 	size.classes.Inheritance$Third -> 8
 Shallow sizes by class:
-	size.classes.Inheritance$Interface -> 24
 	size.classes.Inheritance$Abstract -> 24
 	size.classes.Inheritance$First -> 24
+	size.classes.Inheritance$Interface -> 24
 	size.classes.Inheritance$Second -> 16
 	size.classes.Inheritance$Third -> 8
 Retained sizes by class:
-	size.classes.Inheritance$Interface -> 24
 	size.classes.Inheritance$Abstract -> 24
 	size.classes.Inheritance$First -> 24
+	size.classes.Inheritance$Interface -> 24
 	size.classes.Inheritance$Second -> 16
 	size.classes.Inheritance$Third -> 8

--- a/test_data/outs32/size.classes.ManyClasses.out
+++ b/test_data/outs32/size.classes.ManyClasses.out
@@ -1,5 +1,5 @@
 Agent loaded
 Shallow sizes by class:
-	size.classes.ManyClasses$1ThirdClass -> 0
-	size.classes.OneClass -> 8
 	size.classes.ManyClasses$1SecondClass -> 16
+	size.classes.OneClass -> 8
+	size.classes.ManyClasses$1ThirdClass -> 0

--- a/test_data/outs32/size.classes.ManyClassesTwice.out
+++ b/test_data/outs32/size.classes.ManyClassesTwice.out
@@ -1,9 +1,9 @@
 Agent loaded
 Shallow sizes by class:
-	size.classes.ManyClasses$1ThirdClass -> 0
-	size.classes.OneClass -> 8
 	size.classes.ManyClasses$1SecondClass -> 16
-Shallow sizes by class:
+	size.classes.OneClass -> 8
 	size.classes.ManyClasses$1ThirdClass -> 0
-	size.classes.OneClass -> 16
+Shallow sizes by class:
 	size.classes.ManyClasses$1SecondClass -> 32
+	size.classes.OneClass -> 16
+	size.classes.ManyClasses$1ThirdClass -> 0

--- a/test_data/src/common/TestBase.java
+++ b/test_data/src/common/TestBase.java
@@ -162,9 +162,12 @@ public abstract class TestBase {
 
   private static <T> void printSize(T[] objects, long[] sizes, Function<T, String> toString) {
     assertEquals(objects.length, sizes.length);
+    List<NameAndSize> result = new ArrayList<NameAndSize>();
     for (int i = 0; i < sizes.length; i++) {
-      System.out.println("\t" + toString.apply(objects[i]) + " -> " + sizes[i]);
+      result.add(new NameAndSize(toString.apply(objects[i]), sizes[i]));
     }
+    result.sort(NameAndSize::compareTo);
+    result.forEach(r -> System.out.println("\t" + r.name + " -> " + r.size));
   }
 
   protected static void printShallowAndRetainedSizeByClasses(Class<?>... classes) {
@@ -337,5 +340,20 @@ public abstract class TestBase {
       return Arrays.stream((Object[]) obj).map(x -> asStringImpl(x, visited)).collect(Collectors.joining(", ", "[", "]"));
     }
     return obj.toString().replaceFirst("@.*", "");
+  }
+
+  private static class NameAndSize implements Comparable<NameAndSize> {
+    public String name;
+    public long size;
+
+    public NameAndSize(String name, long size) {
+      this.name = name;
+      this.size = size;
+    }
+
+    @Override
+    public int compareTo(NameAndSize other){
+        return size == other.size ? name.compareTo(other.name) : -Long.compare(size, other.size);
+    }
   }
 }

--- a/test_data/src/execution/RetainedSizeByClassesForObject.java
+++ b/test_data/src/execution/RetainedSizeByClassesForObject.java
@@ -1,0 +1,19 @@
+package execution;
+
+import com.intellij.memory.agent.IdeaNativeAgentProxy;
+import common.TestTreeNode;
+import common.ExecutionTestBase;
+
+public class RetainedSizeByClassesForObject extends ExecutionTestBase {
+    @Override
+    protected MemoryAgentErrorCode executeOperation(IdeaNativeAgentProxy proxy) {
+        Object testObject = new Object();
+        Object target = new Object[]{null, new Object[]{1, testObject}, 1, 2};
+        return getErrorCode(proxy.getRetainedSizeByClasses(new Object[] {Object.class}));
+    }
+
+    public static void main(String[] args) {
+        ExecutionTestBase test = new RetainedSizeByClassesForObject();
+        test.doTest();
+    }
+}

--- a/test_data/src/execution/ShallowAndRetainedSizeByClassesForObject.java
+++ b/test_data/src/execution/ShallowAndRetainedSizeByClassesForObject.java
@@ -1,0 +1,19 @@
+package execution;
+
+import com.intellij.memory.agent.IdeaNativeAgentProxy;
+import common.TestTreeNode;
+import common.ExecutionTestBase;
+
+public class ShallowAndRetainedSizeByClassesForObject extends ExecutionTestBase {
+    @Override
+    protected MemoryAgentErrorCode executeOperation(IdeaNativeAgentProxy proxy) {
+        Object testObject = new Object();
+        Object target = new Object[]{null, new Object[]{1, testObject}, 1, 2};
+        return getErrorCode(proxy.getShallowAndRetainedSizeByClasses(new Object[] {Object.class}));
+    }
+
+    public static void main(String[] args) {
+        ExecutionTestBase test = new ShallowAndRetainedSizeByClassesForObject();
+        test.doTest();
+    }
+}

--- a/test_data/src/execution/ShallowSizeByClassesForObject.java
+++ b/test_data/src/execution/ShallowSizeByClassesForObject.java
@@ -1,0 +1,20 @@
+package execution;
+
+import com.intellij.memory.agent.IdeaNativeAgentProxy;
+import common.TestTreeNode;
+import common.ExecutionTestBase;
+
+public class ShallowSizeByClassesForObject extends ExecutionTestBase {
+    @Override
+    protected MemoryAgentErrorCode executeOperation(IdeaNativeAgentProxy proxy) {
+        Object testObject = new Object();
+        Object target = new Object[]{null, new Object[]{1, testObject}, 1, 2};
+        return getErrorCode(proxy.getShallowSizeByClasses(new Object[] {Object.class}));
+    }
+
+    public static void main(String[] args) {
+        ExecutionTestBase test = new ShallowSizeByClassesForObject();
+        test.doTest();
+    }
+}
+


### PR DESCRIPTION
`jdk/internal/vm/FillerArray` objects are used to mark dead heap areas, see https://bugs.openjdk.org/browse/JDK-8284435
These objects must not be accessible, so they are facultative for analysis. However, these objects are invisible for consecutive jvmti->IterateThroughHeap calls.

In this PR, we ignore instances of this class to avoid [the issue](https://youtrack.jetbrains.com/issue/IDEA-330128).